### PR TITLE
Fix OpenNext dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {
+    "@opennextjs/cloudflare": "^1.12.0",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-dialog": "^1.1.6",
@@ -40,7 +41,6 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@cloudflare/next-on-pages": "^1.13.16",
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20.17.24",
@@ -50,6 +50,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.1-canary.1",
     "tailwindcss": "^4",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.2",
+    "wrangler": "^4.47.0"
   }
 }


### PR DESCRIPTION
## Summary
This PR fixes the  to correctly include the OpenNext dependencies that were missing from PR #19.

## Problem
PR #19 was merged with an incomplete  that still referenced the deprecated  package and was missing the new OpenNext dependencies. This caused a lockfile mismatch error during Cloudflare builds:

```
ERR_PNPM_OUTDATED_LOCKFILE Cannot install with "frozen-lockfile" 
because pnpm-lock.yaml is not up to date with package.json
```

## Changes
- ✅ Add `@opennextjs/cloudflare` to dependencies
- ✅ Add `wrangler` to devDependencies
- ✅ Remove deprecated `@cloudflare/next-on-pages` from devDependencies

## Testing
✅ Verified lockfile is in sync with package.json
✅ `pnpm install` completes successfully

## Impact
This fixes the Cloudflare build failures and completes the OpenNext migration started in PR #19.