### PR TITLE
Fix: Handle soft deleted company updates

### DIFF
--- a/app/company/[slug]/page.tsx
+++ b/app/company/[slug]/page.tsx
@@ -86,10 +86,12 @@ export default async function CompanyPage({ params }: CompanyPageProps) {
     }
 
     // Query using the raw channel_id (MongoDB Long object) to match the database type
+    // Filter out soft-deleted updates (where deleted_at is not null)
     const updates = await db
       .collection("company_updates")
       .find({
         original_channel_id: company.channel_id,
+        deleted_at: null, // Only fetch non-deleted updates
       })
       .sort({ created_at: -1 })
       .limit(3)

--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -167,6 +167,9 @@ Tracks messages posted in company channels for forwarding to a central updates f
   // Reaction Tracking
   reactionUserIds: Array<number>; // User IDs who reacted (any emoji)
 
+  // Soft Delete
+  deleted_at: Date | null; // Timestamp when the message was deleted (soft delete)
+
   // Metadata
   timestamp: Date;
   last_updated: Date;

--- a/lib/models/CompanyUpdate.ts
+++ b/lib/models/CompanyUpdate.ts
@@ -73,6 +73,9 @@ export interface ICompanyUpdate extends Document {
   // Reaction Tracking
   reactionUserIds: number[];
 
+  // Soft Delete
+  deleted_at: Date | null;
+
   // Metadata
   timestamp: Date;
   last_updated: Date;
@@ -162,6 +165,9 @@ const companyUpdateSchema = new Schema<ICompanyUpdate>(
 
     // Reaction Tracking
     reactionUserIds: { type: [Number], default: [] },
+
+    // Soft Delete
+    deleted_at: { type: Date, default: null },
 
     // Metadata
     timestamp: { type: Date, default: Date.now },


### PR DESCRIPTION
This PR fixes the handling of company updates when a company has been soft deleted. It ensures that updates for deleted companies are properly filtered out.